### PR TITLE
[SCAL-428] Show workers info (bugfix)

### DIFF
--- a/app/views/experiments/_workers_info.html.haml
+++ b/app/views/experiments/_workers_info.html.haml
@@ -53,6 +53,10 @@
           $("#workers_alert").show();
           $("#boostButton").addClass("success");
         }
+        else {
+          $("#workers_alert").hide();
+          $("#boostButton").removeClass("success");
+        }
         $("#actions-loading-workers").hide();
       });
     }


### PR DESCRIPTION
Fixed hiding 'No resources in use...' & removing css class 'success' from button 'Add computing power'
