### PR TITLE
Revert "SCAL-347: new initializer - ensure AlgDesign package"

### DIFF
--- a/config/initializers/r_libraries.rb
+++ b/config/initializers/r_libraries.rb
@@ -1,3 +1,0 @@
-Rails.configuration.r_interpreter.eval("if(!require(AlgDesign, quietly=TRUE)){
-                                          install.packages(\"AlgDesign\", repos=\"http://cran.rstudio.com/\", quiet=TRUE)
-                                        }")


### PR DESCRIPTION
Reverts Scalarm/scalarm_experiment_manager#27 because it causes problems on some machines:

Warning in install.packages("AlgDesign", repos = "http://cran.rstudio.com/",  :
  'lib = "/usr/lib64/R/library"' is not writable
^C
Warning message:

In library(package, lib.loc = lib.loc, character.only = TRUE, logical.return = TRUE,  :
  there is no package called ‘AlgDesign’
