### PR TITLE
SCAL-347 - if AlgDesign library missing, initializer installs it in r_li...

### DIFF
--- a/config/initializers/r_libraries.rb
+++ b/config/initializers/r_libraries.rb
@@ -1,0 +1,5 @@
+Rails.configuration.r_interpreter.eval(
+    ".libPaths(c(\"#{Dir.pwd}/r_libs\", .libPaths()))
+    if(!require(AlgDesign, quietly=TRUE)){
+      install.packages(\"AlgDesign\", repos=\"http://cran.rstudio.com/\")
+    }")

--- a/r_libs/.gitignore
+++ b/r_libs/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+


### PR DESCRIPTION
...bs directory
