### PR TITLE
Optimization experiment development

### DIFF
--- a/app/controllers/experiments_controller.rb
+++ b/app/controllers/experiments_controller.rb
@@ -961,7 +961,7 @@ class ExperimentsController < ApplicationController
     validate(
         results: [:optional, :security_json],
         status: [:optional, :security_default],
-        reason: [:optional, :security_default]
+        reason: [:optional, :string]
     )
     raise ValidationError.new(:id, @experiment.id, 'Not a supervised experiment') unless @experiment.supervised
 

--- a/app/views/experiments/_experiment_result.html.haml
+++ b/app/views/experiments/_experiment_result.html.haml
@@ -1,4 +1,8 @@
 %h3.subheader= "Experiment result"
 
-%p
-  #{@experiment.results}
+- unless @experiment.results.nil?
+  %p
+    #{@experiment.results}
+- unless @experiment.error_reason.nil?
+  %p
+    #{@experiment.error_reason}

--- a/app/views/experiments/new/optimization_method/_simulated_annealing.html.haml
+++ b/app/views/experiments/new/optimization_method/_simulated_annealing.html.haml
@@ -2,7 +2,7 @@
   = hidden_field_tag 'simulation_id', @simulation.id
   = hidden_field_tag 'experiment_input'
   = render 'experiments/new/basic_information'
-  = hidden_field_tag 'supervisor_script_id', 'sa'
+  = hidden_field_tag 'supervisor_script_id', 'simulated_annealing'
   = hidden_field_tag 'supervisor_script_params'
 = form_tag experiments_path, id: 'simulated_annealing_form_hidden' do
   = render 'experiments/new/simulated_annealing_form'

--- a/app/views/experiments/show.html.haml
+++ b/app/views/experiments/show.html.haml
@@ -73,7 +73,7 @@
 
   = render 'scheduling_policy_dialog'
 
-- unless @experiment.results.nil?
+- unless @experiment.supervised.nil?
   %section.panel.radius(style="margin-top: 20px;")
     = render 'experiment_result'
 

--- a/test/integration/mark_as_complete_supervised_experiment_test.rb
+++ b/test/integration/mark_as_complete_supervised_experiment_test.rb
@@ -4,21 +4,16 @@ require 'supervised_experiment_helper'
 
 class MarkAsCompleteSupervisedExperimentTest < ActionDispatch::IntegrationTest
   include SupervisedExperimentHelper
-
-  def self.create_supervised_experiment
-    supervised_experiment = ExperimentFactory.create_supervised_experiment(@@user.id, @@simulation)
-    supervised_experiment.save
-    @@experiment_id = supervised_experiment.id
-  end
-
-
+  
   test "successful mark as complete of supervised experiment" do
-    self.class.create_supervised_experiment
+    supervised_experiment = ExperimentFactory.create_supervised_experiment(@user.id, @simulation)
+    supervised_experiment.save
+    experiment_id = supervised_experiment.id
     # test
-    supervised_experiment = SupervisedExperiment.find_by_id(@@experiment_id)
+    supervised_experiment = SupervisedExperiment.find_by_id(experiment_id)
     assert_not supervised_experiment.completed?, 'New experiment must not be completed'
     assert_no_difference 'Experiment.count' do
-      post mark_as_complete_experiment_path(@@experiment_id), results: EXPERIMENT_RESULT.to_json
+      post mark_as_complete_experiment_path(experiment_id), results: EXPERIMENT_RESULT.to_json
     end
     response_hash = JSON.parse(response.body)
     # test if response contains only allowed entries with proper values
@@ -27,14 +22,14 @@ class MarkAsCompleteSupervisedExperimentTest < ActionDispatch::IntegrationTest
     end
     assert_equal response_hash['status'], 'ok'
 
-    supervised_experiment = SupervisedExperiment.find_by_id(@@experiment_id)
+    supervised_experiment = SupervisedExperiment.find_by_id(experiment_id)
     assert supervised_experiment.completed?, 'Marked as complete experiment must be completed'
     assert_equal EXPERIMENT_RESULT, supervised_experiment.results
   end
 
   test "mark as complete should raise exception when experiment is not supervised" do
     # create experiment
-    experiment = ExperimentFactory.create_experiment(@@user.id, @@simulation)
+    experiment = ExperimentFactory.create_experiment(@user.id, @simulation)
     experiment.save
     experiment_id = experiment.id
     # test
@@ -46,11 +41,14 @@ class MarkAsCompleteSupervisedExperimentTest < ActionDispatch::IntegrationTest
   end
 
   test "mark as complete when status is error should set is_error flag on experiment with optional reason" do
-    self.class.create_supervised_experiment
-    supervised_experiment = SupervisedExperiment.find_by_id(@@experiment_id)
+    supervised_experiment = ExperimentFactory.create_supervised_experiment(@user.id, @simulation)
+    supervised_experiment.save
+    experiment_id = supervised_experiment.id
+    
+    supervised_experiment = SupervisedExperiment.find_by_id(experiment_id)
     assert_not supervised_experiment.is_error 'New experiment should not be in error'
     assert_no_difference 'Experiment.count' do
-      post mark_as_complete_experiment_path(@@experiment_id), status: 'error', reason: REASON
+      post mark_as_complete_experiment_path(experiment_id), status: 'error', reason: REASON
     end
     response_hash = JSON.parse(response.body)
     # test if response contains only allowed entries with proper values
@@ -59,7 +57,7 @@ class MarkAsCompleteSupervisedExperimentTest < ActionDispatch::IntegrationTest
     end
     assert_equal response_hash['status'], 'ok'
 
-    supervised_experiment = SupervisedExperiment.find_by_id(@@experiment_id)
+    supervised_experiment = SupervisedExperiment.find_by_id(experiment_id)
     assert supervised_experiment.is_error 'Experiment should be in error after proper query'
     assert_equal supervised_experiment.error_reason, REASON
 
@@ -68,14 +66,14 @@ class MarkAsCompleteSupervisedExperimentTest < ActionDispatch::IntegrationTest
   test "successful start of supervised experiment without starting supervisor script" do
     # mocks
     # mock supervised experiment instance to return specified id (needed to test post params to supervisor)
-    supervised_experiment = ExperimentFactory.create_supervised_experiment(@@user.id, @@simulation)
+    supervised_experiment = ExperimentFactory.create_supervised_experiment(@user.id, @simulation)
     supervised_experiment.expects(:id).returns(BSON::ObjectId(EXPERIMENT_ID))
     ExperimentFactory.expects(:create_supervised_experiment).returns(supervised_experiment)
     # mock experiment supervisor response with testing proper query params
     RestClient.expects(:post).never
     # test
     assert_difference 'Experiment.count', 1 do
-      post "#{start_supervised_experiment_experiments_path}.json", simulation_id: @@simulation.id
+      post "#{start_supervised_experiment_experiments_path}.json", simulation_id: @simulation.id
     end
     response_hash = JSON.parse(response.body)
     # test if response contains only allowed entries with proper values

--- a/test/integration/start_supervised_experiment_test.rb
+++ b/test/integration/start_supervised_experiment_test.rb
@@ -10,7 +10,7 @@ class StartSupervisedExperimentTest < ActionDispatch::IntegrationTest
   test "successful start of supervised experiment with json result" do
     # mocks
     # mock supervised experiment instance to return specified id (needed to test post params to supervisor)
-    supervised_experiment = ExperimentFactory.create_supervised_experiment(@@user.id, @@simulation)
+    supervised_experiment = ExperimentFactory.create_supervised_experiment(@user.id, @simulation)
     supervised_experiment.expects(:id).returns(BSON::ObjectId(EXPERIMENT_ID)).times(3)
     ExperimentFactory.expects(:create_supervised_experiment).returns(supervised_experiment)
 
@@ -28,7 +28,7 @@ class StartSupervisedExperimentTest < ActionDispatch::IntegrationTest
     end.returns(RESPONSE_ON_SUCCESS.to_json)
     # test
     assert_difference 'Experiment.count', 1 do
-      post "#{start_supervised_experiment_experiments_path}.json", simulation_id: @@simulation.id,
+      post "#{start_supervised_experiment_experiments_path}.json", simulation_id: @simulation.id,
              supervisor_script_id: SCRIPT_ID,
              supervisor_script_params: INPUT_SCRIPT_PARAMS.to_json
     end
@@ -49,7 +49,7 @@ class StartSupervisedExperimentTest < ActionDispatch::IntegrationTest
     RestClient.expects(:post).returns(RESPONSE_ON_SUCCESS.to_json)
     #test
     assert_difference 'Experiment.count', 1 do
-      post start_supervised_experiment_experiments_path, simulation_id: @@simulation.id,
+      post start_supervised_experiment_experiments_path, simulation_id: @simulation.id,
            supervisor_script_id: SCRIPT_ID,
            supervisor_script_params: INPUT_SCRIPT_PARAMS.to_json
     end
@@ -66,7 +66,7 @@ class StartSupervisedExperimentTest < ActionDispatch::IntegrationTest
     RestClient.expects(:post).returns(RESPONSE_ON_FAILURE.to_json)
     # test
     assert_no_difference 'Experiment.count' do
-      post "#{start_supervised_experiment_experiments_path}.json", simulation_id: @@simulation.id,
+      post "#{start_supervised_experiment_experiments_path}.json", simulation_id: @simulation.id,
            supervisor_script_id: SCRIPT_ID,
            supervisor_script_params: INPUT_SCRIPT_PARAMS.to_json
     end
@@ -85,7 +85,7 @@ class StartSupervisedExperimentTest < ActionDispatch::IntegrationTest
     RestClient.expects(:post).raises(StandardError, REASON)
     # test
     assert_no_difference 'Experiment.count' do
-      post "#{start_supervised_experiment_experiments_path}.json", simulation_id: @@simulation.id,
+      post "#{start_supervised_experiment_experiments_path}.json", simulation_id: @simulation.id,
            supervisor_script_id: SCRIPT_ID,
            supervisor_script_params: INPUT_SCRIPT_PARAMS.to_json
     end
@@ -105,7 +105,7 @@ class StartSupervisedExperimentTest < ActionDispatch::IntegrationTest
     RestClient.expects(:post).returns(RESPONSE_ON_FAILURE.to_json)
     # test
     assert_no_difference 'Experiment.count', 1 do
-      post start_supervised_experiment_experiments_path, simulation_id: @@simulation.id,
+      post start_supervised_experiment_experiments_path, simulation_id: @simulation.id,
            supervisor_script_id: SCRIPT_ID,
            supervisor_script_params: INPUT_SCRIPT_PARAMS.to_json
     end

--- a/test/supervised_experiment_helper.rb
+++ b/test/supervised_experiment_helper.rb
@@ -30,10 +30,28 @@ module SupervisedExperimentHelper
       'experiment_id' => EXPERIMENT_ID,
       'user' => USER_NAME,
       'password' => PASSWORD,
-      'lower_limit' =>[-3, -2],
-      'upper_limit' =>[3, 2],
-      'parameters_ids' => %w(c___g___x c___g___y),
-      'start_point' =>[0, 0],
+      'parameters' => [
+          {
+              'type' => 'float',
+              'id' => 'c___g___x',
+              'min' => -3,
+              'max' => 3,
+              'start_value' => 0
+          },
+          {
+              'type' => 'int',
+              'id' => 'c___g___y',
+              'min' => -2,
+              'max' => 2,
+              'start_value' => 0
+          },
+          {
+              'type' => 'string',
+              'id' => 'c___g___z',
+              'allowed_values' => %w(aaa bbb ccc),
+              'start_value' => 'aaa'
+          }
+      ],
   }
   INPUT_SPECIFICATION = [
       {
@@ -53,18 +71,23 @@ module SupervisedExperimentHelper
                                   'min' => -3,
                                   'max' => 3,
                                   'index' => 1,
-                                  'parametrizationType' => 'value',
                                   'value' => '-3'
                               },
                               {
                                   'id' => 'y',
                                   'label' => 'y',
-                                  'type' => 'float',
+                                  'type' => 'int',
                                   'min' => -2,
                                   'max' => 2,
                                   'index' => 2,
-                                  'parametrizationType' => 'value',
                                   'value' => '-2'
+                              },
+                              {
+                                  'id' => 'z',
+                                  'label' => 'z',
+                                  'type' => 'string',
+                                  'index' => 3,
+                                  'allowed_values' => %w(aaa bbb ccc)
                               }
                           ]
                   }
@@ -88,9 +111,10 @@ module SupervisedExperimentHelper
     @@simulation.user_id = @@user.id
     @@simulation.save
     # mock information service
-    information_service = mock()
-    information_service.stubs(:get_list_of).returns([])
-    information_service.stubs(:sample_public_url).returns(nil)
+    information_service = mock do
+      stubs(:get_list_of).returns([])
+      stubs(:sample_public_url).returns(nil)
+    end
     InformationService.stubs(:new).returns(information_service)
   end
 

--- a/test/supervised_experiment_helper.rb
+++ b/test/supervised_experiment_helper.rb
@@ -10,19 +10,20 @@ module SupervisedExperimentHelper
   PID = 'pid'
   EXPERIMENT_SUPERVISOR_ADDRESS = 'http://localhost:13337/start_supervisor_script'
   RESPONSE_ON_SUCCESS = {
-      'status' => 'ok',
-      'pid' => PID
+      status: 'ok',
+      pid: PID
   }
   REASON = 'reason'
   RESPONSE_ON_FAILURE = {
-      'status' => 'error',
-      'reason' => REASON
+      status: 'error',
+      reason: REASON
   }
   INPUT_SCRIPT_PARAMS = {
-      'maxiter' => 1,
-      'dwell' => 1,
-      'schedule' => 'boltzmann'
+      maxiter: 1,
+      dwell: 1,
+      schedule: 'boltzmann'
   }
+  # Here must be strings as hash keys, JSON.parse returns hash with strings as keys
   FULL_SCRIPT_PARAMS = {
       'maxiter' => 1,
       'dwell' => 1,
@@ -53,6 +54,7 @@ module SupervisedExperimentHelper
           }
       ],
   }
+  # Here must be strings as hash keys
   INPUT_SPECIFICATION = [
       {
           'id' => 'c',
@@ -94,22 +96,22 @@ module SupervisedExperimentHelper
               ]
       }
   ]
+  # Here must be strings as hash keys
   EXPERIMENT_RESULT = {
       'result' => 'result'
   }
 
-  @@simulation = Simulation.new(name: 'name', description: 'description',
-                                input_parameters: {}, input_specification: INPUT_SPECIFICATION)
-  @@user = ScalarmUser.new({login: USER_NAME})
-
   def setup
     super
     # log in user and set sample simulation
-    @@user.password = PASSWORD
-    @@user.save
+    @user = ScalarmUser.new({login: USER_NAME})
+    @user.password = PASSWORD
+    @user.save
     post login_path, username: USER_NAME, password: PASSWORD
-    @@simulation.user_id = @@user.id
-    @@simulation.save
+    @simulation = Simulation.new(name: 'name', description: 'description',
+                                  input_parameters: {}, input_specification: INPUT_SPECIFICATION)
+    @simulation.user_id = @user.id
+    @simulation.save
     # mock information service
     information_service = mock do
       stubs(:get_list_of).returns([])


### PR DESCRIPTION
Pull request zamykający zadanie SCAL-636. Zawiera drobne zmiany które okazały się konieczne w czasie rozwoju, refaktoring testów oraz zmianę API Scalarma w części przekazywania parametrów przestrzeni do skrypt nadzorującego. Nowy format zgodzie z ustaleniami wygląda następująco:
```
      'parameters' => [
          {
              'type' => 'float',
              'id' => 'c___g___x',
              'min' => -3,
              'max' => 3,
              'start_value' => 0
          },
          {
              'type' => 'int',
              'id' => 'c___g___y',
              'min' => -2,
              'max' => 2,
              'start_value' => 0
          },
          {
              'type' => 'string',
              'id' => 'c___g___z',
              'allowed_values' => %w(aaa bbb ccc),
              'start_value' => 'aaa'
          }
      ]
```