### PR TITLE
SCAL 698 Remove prepare_new_experiment

### DIFF
--- a/app/controllers/experiments_controller.rb
+++ b/app/controllers/experiments_controller.rb
@@ -145,7 +145,9 @@ class ExperimentsController < ApplicationController
     #validate_params(:json, :doe) # TODO :experiment_input :parameters_constraints,
 
     begin
-      experiment = ExperimentFactory.create_experiment(@current_user.id, @simulation, params)
+      parsed_params = params.permit(:replication_level, :time_constraint_in_sec, :scheduling_policy, :name,
+                                   :description, :parameter_constraints)
+      experiment = ExperimentFactory.create_experiment(@current_user.id, @simulation, parsed_params)
 
       if request.fullpath.include?("start_import_based_experiment")
         input_space_imported_specification(experiment)

--- a/app/controllers/experiments_controller.rb
+++ b/app/controllers/experiments_controller.rb
@@ -145,7 +145,7 @@ class ExperimentsController < ApplicationController
     #validate_params(:json, :doe) # TODO :experiment_input :parameters_constraints,
 
     begin
-      experiment = prepare_new_experiment
+      experiment = ExperimentFactory.create_experiment(@current_user.id, @simulation, params)
 
       if request.fullpath.include?("start_import_based_experiment")
         input_space_imported_specification(experiment)
@@ -859,29 +859,6 @@ class ExperimentsController < ApplicationController
       experiment.doe_info = [ [ 'csv_import', importer.parameters, importer.parameter_values ] ]
       experiment.experiment_input = Experiment.prepare_experiment_input(@simulation, {}, experiment.doe_info)
     end
-  end
-
-  def prepare_new_experiment
-
-    replication_level = params['replication_level'].blank? ? 1 : params['replication_level'].to_i
-    time_constraint = params['execution_time_constraint'].blank? ? 3600 : params['execution_time_constraint'].to_i * 60
-    parameters_constraints = params[:parameters_constraints].blank? ? {} : Utils.parse_json_if_string(params[:parameters_constraints])
-
-    # TODO: use ExperimentsFactory
-    # create the new type of experiment object
-    experiment = Experiment.new({'simulation_id' => @simulation.id,
-                                 'is_running' => true,
-                                 'replication_level' => replication_level,
-                                 'time_constraint_in_sec' => time_constraint,
-                                 'start_at' => Time.now,
-                                 'user_id' => @current_user.id,
-                                 'scheduling_policy' => 'monte_carlo'
-                                })
-    experiment.name = params['experiment_name'].blank? ? @simulation.name : params['experiment_name']
-    experiment.description = params['experiment_description'].blank? ? @simulation.description : params['experiment_description']
-    experiment.parameters_constraints = parameters_constraints
-
-    experiment
   end
 
 end

--- a/test/integration/create_params_filtering_test.rb
+++ b/test/integration/create_params_filtering_test.rb
@@ -1,0 +1,57 @@
+require 'test_helper'
+require 'db_helper'
+
+class CreateParamsFilteringTest < ActionDispatch::IntegrationTest
+  include DBHelper
+
+  INPUT_SPECIFICATION = [
+      {
+          'id' => 'c',
+          'label' => 'Opis funkcji',
+          'entities' =>
+              [
+                  {
+                      'id' => 'g',
+                      'label' => 'Argumenty funkcji',
+                      'parameters' =>
+                          [
+                          ]
+                  }
+              ]
+      }
+  ]
+  PASSWORD = 'password'
+  USER_NAME = 'user_name'
+
+  def setup
+    super
+    # log in user and set sample simulation
+    @user = ScalarmUser.new({login: USER_NAME})
+    @user.password = PASSWORD
+    @user.save
+    post login_path, username: USER_NAME, password: PASSWORD
+    @simulation = Simulation.new(name: 'name', description: 'description',
+                                 input_parameters: {}, input_specification: INPUT_SPECIFICATION)
+    @simulation.user_id = @user.id
+    @simulation.save
+    # mock information service
+    information_service = mock do
+      stubs(:get_list_of).returns([])
+      stubs(:sample_public_url).returns(nil)
+    end
+    InformationService.stubs(:new).returns(information_service)
+  end
+
+  test 'create should filter forbidden values in params passed to experiment factory' do
+    assert_difference 'Experiment.count', 1 do
+      post "#{experiments_path}.json", simulation_id: @simulation.id, doe: [].to_json,
+           experiment_input: INPUT_SPECIFICATION.to_json,
+           bad_param: 'param'
+    end
+    id = JSON.parse(response.body)["experiment_id"]
+
+    experiment = Experiment.find_by_id(id)
+    assert_not experiment.attributes.has_key?("bad_param"), 'Bad params should be filtered'
+  end
+
+end


### PR DESCRIPTION
prepare_new_experiment pokrywa się z użyciem fabryki, więc zostało usunięte. Obecnie params nie jest w fabryce bezpośrednio zapisywane do bazy, jednak jeśli powstanie taka możliwość należałoby sprawdzić zawartość params. Tutaj jest sposób jak to wygodnie zrobić: http://api.rubyonrails.org/classes/ActionController/Parameters.html