### PR TITLE
SCAL-1021: Problem with basic scenario output

### DIFF
--- a/app/models/utils.rb
+++ b/app/models/utils.rb
@@ -96,7 +96,7 @@ module Utils
     elsif value.is_a? Float
       type_of_value = "float"
     elsif value.is_a? String
-      type_of_value = "string"
+      type_of_value = extract_type_from_string(value)
     else
       type_of_value = "undefined"
     end


### PR DESCRIPTION
Problem was when output variable could be given as string and it was not evaluated properly as for input parameters.