### PR TITLE
SCAL-1159: Date/time rendered in JS in sm_dialog

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -98,3 +98,7 @@ $.prototype.disable = function () {
 String.prototype.with_delimeters = string_with_delimeters;
 
 window.loaderHTML = '<div class="row small-1 small-centered" style="margin-bottom: 10px;"><img src="/assets/loading.gif"/></div>'
+
+function display_date(div_selector, epoch_seconds) {
+    $(div_selector).html(new Date(epoch_seconds * 1000).toString());
+}

--- a/app/views/infrastructures/_sm_dialog.html.haml
+++ b/app/views/infrastructures/_sm_dialog.html.haml
@@ -61,20 +61,22 @@
       - elsif record.state == :initialized
         %li
           %strong= t('infrastructures.sm_dialog.sm_initialized_at') + ':'
-          =record.sm_initialized_at.to_s
+          #sm-installed-at-date
       %li
         %strong= t('infrastructures.sm_dialog.created_at') + ': '
-        =record.created_at.strftime('%Y-%m-%d %H:%M:%S')
+        #sm-created-at-date{style: 'display: inline;'}
       %li
         %strong= t('infrastructures.sm_dialog.time_limit') + ': '
-        =record.created_at.since(record.time_limit.to_i.minutes).to_s + ' ' + "(#{record.time_limit.to_s} minutes)"
+        ="#{record.time_limit.to_s} minutes (will work until: "
+        - time_limit_until = record.created_at.since(record.time_limit.to_i.minutes).to_i
+        #sm-time-limit-until{style: 'display: inline'}
+        =')'
       %li
         %strong= t('infrastructures.sm_dialog.experiment') + ': '
         - if record.experiment
           = link_to "#{record.experiment.name}", experiment_path(record.experiment_id)
         - else
           = t('infrastructure.information.sm_record_error', error: t('infrastructure.information.experiment_not_found'))
-
 
 
 - rescue Exception => e
@@ -85,4 +87,8 @@
     $(document).foundation();
 
     new window.SmDialog("#dialog", "#{facade.short_name}", "#{record.id}");
+
+    display_date("#sm-initialized-at-date", #{record.initialized_at.to_i});
+    display_date("#sm-created-at-date", #{record.created_at.to_i});
+    display_date("#sm-time-limit-until", #{time_limit_until});
   });


### PR DESCRIPTION
New JS global function: display_date which accepts jQuery selector of div to render date string and date in epoch (seconds - as in Ruby Time.new.to_i)

@mwrona @mpaciore - przy okazji prób jak to jest z tym parsowaniem dat, zrobiłem takie coś. Proponuję, żebyście użyli tej funkcji w Waszym GUI, żeby nie powtarzać potem kodu w kilku miejscach.

PROSZĘ NIE MERGOWAĆ TEGO PULL REQUESTA