### PR TITLE
WSS-28: Changing AlgorithmRunner architecture

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -219,6 +219,7 @@ end
 # - ExperimentWatcher - check periodically if some SimulationRuns does not
 #   exceeded their time limit (probably they are faulty)
 # - InfrastructureFacade monitoring - multiple threads for SimulationManagers status monitoring
+# - WorkersScaling::AlgorithmRunner - thread maintaining all Worker Scaling Algorithms
 def monitoring_process(action)
   probe_pid_path = File.join(Rails.root, 'tmp', 'scalarm_monitoring_probe.pid')
 
@@ -251,6 +252,9 @@ def monitoring_process(action)
 
           Rails.logger.info('Starting monitoring threads for all infrastructures')
           threads += InfrastructureFacadeFactory.start_all_monitoring_threads.to_a
+
+          Rails.logger.info('Starting algorithm runner')
+          threads << WorkersScaling::AlgorithmRunner.start
 
           # do not quit this process until all threads are working
           threads.each &:join

--- a/app/controllers/experiments_controller.rb
+++ b/app/controllers/experiments_controller.rb
@@ -413,24 +413,12 @@ class ExperimentsController < ApplicationController
         end
       end
 
-      Thread.new do
-        begin
-          algorithm = WorkersScaling::AlgorithmFactory.create_algorithm(
-              name: workers_scaling_params[:name].to_sym,
-              experiment_id: experiment.id,
-              user_id: current_user.id,
-              allowed_infrastructures: allowed_infrastructures,
-              planned_finish_time: Time.now + workers_scaling_params[:time_limit].minutes,
-              last_update_time: Time.now
-          )
-          algorithm.initial_deployment
-          algorithm.update_next_execution_time
-          WorkersScaling::LOGGER.debug 'Initial deployment finished'
-        rescue => e
-          WorkersScaling::LOGGER.error "Exception occurred during initial deployment: #{e.to_s}\n#{e.backtrace.join("\n")}"
-          raise
-        end
-      end
+      WorkersScaling::AlgorithmFactory.initial_deployment(
+          experiment.id,
+          current_user.id,
+          allowed_infrastructures,
+          workers_scaling_params
+      )
     end
   end
 

--- a/app/controllers/simulations_controller.rb
+++ b/app/controllers/simulations_controller.rb
@@ -345,9 +345,9 @@ class SimulationsController < ApplicationController
           else
             @experiment.progress_bar_update(@simulation_run.index, 'done')
           end
-
-          algorithm_runner = WorkersScaling::AlgorithmRunner.get(@experiment.id)
-          Thread.new { algorithm_runner.execute_and_schedule } if algorithm_runner
+          Thread.new do
+            WorkersScaling::AlgorithmRunner.execute_and_schedule(@experiment.id)
+          end
         end
       end
     rescue Exception => e

--- a/app/models/mongo_lock.rb
+++ b/app/models/mongo_lock.rb
@@ -79,5 +79,15 @@ module Scalarm
       end
     end
 
+    def self.try_mutex(name, probe_sec=0.1, &block)
+      lock = MongoLock.new(name)
+      return unless lock.acquire
+      begin
+        yield
+      ensure
+        lock.release
+      end
+    end
+
   end
 end

--- a/app/models/workers_scaling/algorithm.rb
+++ b/app/models/workers_scaling/algorithm.rb
@@ -1,25 +1,65 @@
+require_relative 'experiment_resources_interface'
+require_relative 'experiment_statistics'
 module WorkersScaling
   ##
   # Class describing interface of Workers scaling algorithm. Creating new algorithm
   # requires providing class with proper methods implemented, which also should
   # inherit Algorithm class.
-  class Algorithm
+  class Algorithm < Scalarm::Database::MongoActiveRecord
+    use_collection 'workers_scaling_algorithms'
+    attr_accessor :experiment
+    attr_accessor :resources_interface
+    attr_accessor :experiment_statistics
 
     NOT_IMPLEMENTED = 'This is an abstract method, which must be implemented by all subclasses'
+    ALGORITHM_INTERVAL = 30.seconds
 
     ##
-    # Arguments:
-    # * experiment - instance of Experiment
-    # * user_id - id of User starting Algorithm
-    # * allowed_infrastructures - list of hashes with infrastructure and maximal Workers amount
-    #     (Detailed description at ExperimentResourcesInterface#initialize)
-    # * planned_finish_time - desired time of end of Experiment (as Time instance)
-    # * params - additional params, currently unused, may be used in subclasses
-    def initialize(experiment, user_id, allowed_infrastructures, planned_finish_time, params = {})
-      @experiment = experiment
+    # Returns name of Algorithm implementation class
+    def self.get_class_name
+      self.name.gsub('::', '__').underscore.to_sym
+    end
+
+    ##
+    # Finds all records of Algorithm implementations
+    # Returns hash containing {experiment_id => next_execution_time} pair for each record
+    def self.get_all_algorithms_times
+      self.where({}, {fields: [:experiment_id, :next_execution_time]}).map do |record|
+        [record.experiment_id, record.next_execution_time]
+      end .to_h
+    end
+
+    ##
+    # Arguments: attributes hash containing fields:
+    #  * experiment_id - id of Experiment
+    #  * user_id - id of User starting Algorithm
+    #  * allowed_infrastructures - list of hashes with infrastructure and maximal Workers amount
+    #      (Detailed description at ExperimentResourcesInterface#initialize)
+    #  * planned_finish_time - desired time of end of Experiment (as Time instance)
+    #  * last_update_time - time of last change of user-defined fields (allowed_infrastructures, planned_finish_time)
+    #  * params (optional) - additional params, currently unused, may be used in subclasses
+    # All these fields are available in any Algorithm as if attr_accessor was created for each of them
+    def initialize(attributes)
+      super(attributes)
+    end
+
+    ##
+    # Must be executed before running #initial_deployment or #experiment_status_check
+    # Initializes fields that are not stored in database:
+    #  * @experiment
+    #  * @resources_interface
+    #  * @experiment_statistics
+    # Returns self to allow chaining
+    def initialize_runtime_fields
+      @experiment = Experiment.find_by_id(experiment_id)
       @resources_interface = ExperimentResourcesInterface.new(@experiment, user_id, allowed_infrastructures)
       @experiment_statistics = ExperimentStatistics.new(@experiment, @resources_interface)
-      @planned_finish_time = planned_finish_time
+      self
+    end
+
+    def save
+      self.class_name = self.class.get_class_name
+      super
     end
 
     ##
@@ -35,6 +75,11 @@ module WorkersScaling
     # when given time since last execution passed. Should contain main algorithm logic.
     def experiment_status_check
       raise NOT_IMPLEMENTED
+    end
+
+    def update_next_execution_time
+      self.next_execution_time = Time.now + ALGORITHM_INTERVAL
+      save
     end
 
   end

--- a/app/models/workers_scaling/algorithm.rb
+++ b/app/models/workers_scaling/algorithm.rb
@@ -88,6 +88,7 @@ module WorkersScaling
       self.errors_count += 1
       if self.errors_count > ERRORS_MAX
         destroy
+        # TODO: notify user
       else
         save
       end

--- a/app/models/workers_scaling/algorithm_runner.rb
+++ b/app/models/workers_scaling/algorithm_runner.rb
@@ -3,96 +3,69 @@ module WorkersScaling
   ##
   # Scheduler to run Algorithm decision loop periodically
   class AlgorithmRunner
-    @@cache = {}
+
+    RUNNER_INTERVAL = 15.seconds
+    THREADS_NUMBER = 4
 
     ##
-    # Returns instance of AlgorithmRunner for experiment_id if registered
-    # Otherwise returns nil
-    def self.get(experiment_id)
-      LOGGER.debug "Getting runner from cache, experiment id: #{experiment_id}"
-      return @@cache[experiment_id.to_s] if @@cache
-    end
-
-    ##
-    # Registers instance of AlgorithmRunner for experiment_id
-    def self.put(experiment_id, runner)
-      @@cache[experiment_id.to_s] = runner
-      LOGGER.debug "Adding runner to cache, experiment id: #{experiment_id}"
-    end
-
-    ##
-    # Unregisters instance of AlgorithmRunner for experiment_id
-    def self.delete(experiment_id)
-      @@cache.delete(experiment_id.to_s) if @@cache
-      LOGGER.debug "Deleting runner from cache, experiment id: #{experiment_id}"
-    end
-
-    ##
-    # Expects:
-    # * instance of Experiment
-    # * instance of Algorithm for given Experiment
-    # * interval between decision loop executions in seconds
-    def initialize(experiment, algorithm, interval)
-      @experiment = experiment
-      @algorithm = algorithm
-      @interval = interval
-      @mutex = Mutex.new
-
-      self.class.put(@experiment.id, self)
-    end
-
-    ##
-    # Initializes Algorithm, then starts its decision loop
-    # Stops when there is no next execution time set
-    def start
+    # Runs periodically and loads some data from all saved Algorithms
+    # If next_execution_time has passed, starts execute_and_schedule for this algorithm
+    def self.start
       Thread.new do
         begin
-          @algorithm.initial_deployment
-          @next_execution_time = Time.now + @interval
-
-          @mutex.synchronize do
-            catch :finished do
-              until @next_execution_time.nil?
-
-                while @next_execution_time > Time.now do
-                  @mutex.sleep @next_execution_time - Time.now
-                  throw :finished if @next_execution_time.nil?
-                end
-
-                execute_and_schedule
+          while true do
+            LOGGER.debug 'Entering Algorithm Runner loop'
+            work_queue = Queue.new
+            Algorithm.get_all_algorithms_times.each do |experiment_id, next_execution_time|
+              if next_execution_time <= Time.now
+                work_queue.push(experiment_id)
               end
             end
-          end
 
-          self.class.delete(@experiment.id)
+            threads = (1..THREADS_NUMBER).map do
+              Thread.new do
+                until work_queue.empty?
+                  execute_and_schedule(work_queue.pop)
+                end
+              end
+            end
+
+            threads.each &:join
+
+            sleep(RUNNER_INTERVAL)
+          end
         rescue => e
-          LOGGER.error "Exception occurred during workers scaling algorithm: #{e.to_s}\n#{e.backtrace.join("\n")}"
+          LOGGER.error "Exception occurred during Algorithm Runner loop: #{e.to_s}\n#{e.backtrace.join("\n")}"
           raise
         end
       end
     end
 
     ##
+    # Arguments:
+    #  * experiment_id - id of experiment which algorithm should be executed
     # Executes decision loop of Algorithm, then schedules next execution
-    # Next execution time is not set when Experiment is completed
-    def execute_and_schedule
-      should_unlock = false
-      unless @mutex.owned?
-        @mutex.lock
-        should_unlock = true
+    # Algorithm is destroyed when Experiment is completed
+    def self.execute_and_schedule(experiment_id)
+      begin
+        Scalarm::MongoLock.try_mutex("experiment-#{experiment_id}-workers-scaling") do
+          experiment = Experiment.find_by_id(experiment_id)
+          algorithm = AlgorithmFactory.get_algorithm(experiment_id)
+
+          if experiment.nil? or experiment.completed?
+            algorithm.destroy
+            LOGGER.debug 'Experiment is completed, destroying algorithm record'
+          else
+            LOGGER.debug 'Starting experiment_status_check method'
+            algorithm.experiment_status_check
+            algorithm.update_next_execution_time
+            LOGGER.debug "Setting next execution time to #{algorithm.next_execution_time.inspect}"
+          end
+        end
+      rescue => e
+        LOGGER.error "Exception occurred during workers scaling algorithm: #{e.to_s}\n#{e.backtrace.join("\n")}"
+        raise
       end
-
-      LOGGER.debug "Starting experiment_status_check method, #{should_unlock ? 'asynchronous' : 'synchronous'} call"
-      @algorithm.experiment_status_check
-
-      @next_execution_time = if @experiment.reload.completed?
-                               nil
-                             else
-                               Time.now + @interval
-                             end
-      LOGGER.debug "Setting @next_execution_time to #{@next_execution_time.inspect}"
-
-      @mutex.unlock if should_unlock
     end
 
   end

--- a/app/models/workers_scaling/algorithms/sample_algorithm.rb
+++ b/app/models/workers_scaling/algorithms/sample_algorithm.rb
@@ -11,12 +11,6 @@ module WorkersScaling
     TOLERANCE = 10
 
     ##
-    # Arguments: see Algorithm#initialize
-    def initialize(experiment, user_id, allowed_infrastructures, planned_finish_time, params = {})
-      super(experiment, user_id, allowed_infrastructures, planned_finish_time, params)
-    end
-
-    ##
     # Schedules one Worker on each available infrastructure if Experiment size is greater than infrastructures number
     # Otherwise uses random subset of available infrastructures with size equal to Experiment size
     def initial_deployment
@@ -37,7 +31,7 @@ module WorkersScaling
       LOGGER.debug 'experiment_status_check'
       @experiment.reload
       current_makespan = @experiment_statistics.makespan(cond: Query::RUNNING_WORKERS)
-      case time_constraint_check(current_makespan, @planned_finish_time - Time.now)
+      case time_constraint_check(current_makespan, planned_finish_time - Time.now)
         when :increase
           increase_computational_power
         when :decrease
@@ -53,7 +47,7 @@ module WorkersScaling
     # Returns :ok otherwise
     # Arguments:
     # * predicted - predicted time until Experiment end in seconds
-    # * left - time left until @planned_finish_time in seconds
+    # * left - time left until planned_finish_time in seconds
     def time_constraint_check(predicted, left)
       LOGGER.debug "Time predicted: #{'%.5f' % predicted} s, time left: #{'%.5f' % left} s"
       return :increase if predicted > left * (1 + TOLERANCE/100)
@@ -70,7 +64,7 @@ module WorkersScaling
       LOGGER.debug 'Need to increase computational power'
 
       # calculate needed additional throughput
-      throughput_needed = @experiment_statistics.target_throughput(@planned_finish_time) -
+      throughput_needed = @experiment_statistics.target_throughput(planned_finish_time) -
                           @experiment_statistics.system_throughput
       LOGGER.debug "Additional throughput needed: #{'%.5f' % throughput_needed} sim/s"
 
@@ -127,7 +121,7 @@ module WorkersScaling
 
       # calculate excess throughput
       excess_throughput = @experiment_statistics.system_throughput -
-                          @experiment_statistics.target_throughput(@planned_finish_time)
+                          @experiment_statistics.target_throughput(planned_finish_time)
       LOGGER.debug "Excess throughput: #{'%.5f' % excess_throughput} sim/s"
 
       # get all workers with their throughput

--- a/app/models/workers_scaling/experiment_resources_interface.rb
+++ b/app/models/workers_scaling/experiment_resources_interface.rb
@@ -21,7 +21,7 @@ module WorkersScaling
       @experiment = experiment
       @user_id = BSON::ObjectId(user_id.to_s)
       @facades_cache = {}
-      @allowed_infrastructures = allowed_infrastructures
+      @allowed_infrastructures = allowed_infrastructures.map {|x| ActiveSupport::HashWithIndifferentAccess.new(x)}
     end
 
     ##
@@ -37,6 +37,7 @@ module WorkersScaling
             InfrastructureFacadeFactory.get_facade_for(infrastructure_name).get_subinfrastructures(@user_id)
           end
           .select {|x| !!@allowed_infrastructures.detect {|ai| infrastructures_equal?(x, ai[:infrastructure])}}
+          .map {|x| ActiveSupport::HashWithIndifferentAccess.new(x)}
       # TODO return allowed infrastructures filter by available
     end
 


### PR DESCRIPTION
https://jira.plgrid.pl/jira/browse/SCAL-1113

 * Algorithms are saved to database
 * AlgorithmRunner now runs in background, runs Algorithms that are saved into database
 * AlgorithmRunner has pool of threads
 * If Algorithm is already running (e.g. in another EM instance) then its execution is skipped
 * AlgorithmFactory caches Algorithms, validates their last_update_time
 * Allowed infrastructure are converted to HashWithIndifferentAccess for compatibility with database