### PR TITLE
SCAL-1191: WSS-42 Disabling scheduling workers on error

### DIFF
--- a/app/controllers/experiments_controller.rb
+++ b/app/controllers/experiments_controller.rb
@@ -417,7 +417,7 @@ apiDoc:
       Utils::raise_error_unless_has_key(params, :workers_scaling_params, message_prefix.pluralize)
       workers_scaling_params = Utils::parse_json_if_string(params[:workers_scaling_params]).symbolize_keys
       if workers_scaling_params[:plgrid_default]
-        if InfrastructureFacadeFactory.get_facade_for(:qsub).get_subinfrastructures(current_user.id).blank?
+        if InfrastructureFacadeFactory.get_facade_for(:qsub).get_infrastructure_configurations(current_user.id).blank?
           raise InfrastructureErrors::NoCredentialsError.new('Missing credentials for PlGrid resources')
         end
       else

--- a/app/models/experiment.rb
+++ b/app/models/experiment.rb
@@ -86,6 +86,11 @@ class Experiment < Scalarm::Database::Model::Experiment
     experiment_size > (sent+done)
   end
 
+  def count_simulations_to_run
+    _, sent, done = get_statistics
+    experiment_size - (sent + done)
+  end
+
   # Should, in this moment, more computations for this experiment should be made?
   def end?
     (self.is_running == false) or completed?

--- a/app/models/infrastructure_facades/cloud_facade.rb
+++ b/app/models/infrastructure_facades/cloud_facade.rb
@@ -153,7 +153,7 @@ class CloudFacade < InfrastructureFacade
   ##
   # Returns list of hashes representing distinct configurations of infrastructure
   # Delegates method to classes inheriting from #AbstractCloudClient
-  def get_subinfrastructures(user_id)
+  def get_infrastructure_configurations(user_id)
     creds = CloudSecrets.find_by_query(cloud_name: @short_name, user_id: user_id)
     cloud_client = nil
     begin
@@ -163,7 +163,7 @@ class CloudFacade < InfrastructureFacade
     end
     return [] if (cloud_client == nil or not cloud_client.valid_credentials?)
 
-    cloud_client.get_subinfrastructures(user_id)
+    cloud_client.get_infrastructure_configurations(user_id)
   end
 
   # -- SimulationManager delegation methods --

--- a/app/models/infrastructure_facades/clouds/abstract_cloud_client.rb
+++ b/app/models/infrastructure_facades/clouds/abstract_cloud_client.rb
@@ -2,7 +2,7 @@
 # - all_images_info -> get array of hashes: image_identifier => image label for all images permitted to use by cloud user
 # - instantiate_vms(base_instace_name, image_id, number) => list of instance ids (Strings)
 # - all_vm_ids -> get array of VM ids (Strings)
-# - get_subinfrastructures(user_id) -> list of hashes representing distinct configurations of infrastructure
+# - get_infrastructure_configurations(user_id) -> list of hashes representing distinct configurations of infrastructure
 # Methods for checking and changing virtual machine state (taking vm id)
 # - status -> one of: [:intializing, :running, :deactivated, :rebooting, :error]
 # - exists? -> true if VM exists (instance with given @instance_id is still available)
@@ -63,7 +63,7 @@ class AbstractCloudClient
   # Subinfrastructures are distinguished by:
   #  * type of machine instance
   #  * image secrets
-  def get_subinfrastructures(user_id)
+  def get_infrastructure_configurations(user_id)
     instance_types_list = instance_types.map { |type, _| type }
     image_secrets_ids = CloudImageSecrets
         .find_all_by_query(user_id: user_id, cloud_name: self.class.short_name.to_s)

--- a/app/models/infrastructure_facades/clouds/providers/amazon.rb
+++ b/app/models/infrastructure_facades/clouds/providers/amazon.rb
@@ -102,7 +102,7 @@ module AmazonCloud
     # Invokes method from super class
     # Further distinguishes subinfrastructures by:
     #  * security group
-    def get_subinfrastructures(user_id)
+    def get_infrastructure_configurations(user_id)
       security_groups_list = security_groups
       super(user_id).flat_map do |subinfrastructure|
         security_groups_list.flat_map do |security_group|

--- a/app/models/infrastructure_facades/infrastructure_facade.rb
+++ b/app/models/infrastructure_facades/infrastructure_facade.rb
@@ -375,7 +375,7 @@ class InfrastructureFacade
   ##
   # Returns list of hashes representing distinct configurations of infrastructure
   # Overridden in most of subclasses
-  def get_subinfrastructures(user_id)
+  def get_infrastructure_configurations(user_id)
     [{name: short_name.to_sym, params: {}}]
   end
 

--- a/app/models/infrastructure_facades/pl_grid_facade.rb
+++ b/app/models/infrastructure_facades/pl_grid_facade.rb
@@ -296,8 +296,8 @@ class PlGridFacade < InfrastructureFacade
   ##
   # Returns list of hashes representing distinct configurations of infrastructure
   # Delegates method to classes inheriting from #PlGridSchedulerBase
-  def get_subinfrastructures(user_id)
-    scheduler.get_subinfrastructures(user_id)
+  def get_infrastructure_configurations(user_id)
+    scheduler.get_infrastructure_configurations(user_id)
   end
   
   # Appends PL-Grid scheduler name to shared SSH session ID

--- a/app/models/infrastructure_facades/plgrid/grid_schedulers/qcg.rb
+++ b/app/models/infrastructure_facades/plgrid/grid_schedulers/qcg.rb
@@ -220,7 +220,7 @@ module QcgScheduler
     # Subinfrastructures are distinguished by:
     #  * PLGrid hosts
     #  * grant ids
-    def get_subinfrastructures(user_id)
+    def get_infrastructure_configurations(user_id)
       hosts = self.class.available_hosts
       grant_ids = PlGridFacade.retrieve_grants(GridCredentials.find_by_user_id(user_id))
 

--- a/app/models/infrastructure_facades/plgrid/grid_schedulers/qsub.rb
+++ b/app/models/infrastructure_facades/plgrid/grid_schedulers/qsub.rb
@@ -167,7 +167,7 @@ cd $PBS_O_WORKDIR
     # Returns list of hashes representing distinct configurations of infrastructure
     # Subinfrastructures are distinguished by:
     #  * grant ids
-    def get_subinfrastructures(user_id)
+    def get_infrastructure_configurations(user_id)
       PlGridFacade.retrieve_grants(GridCredentials.find_by_user_id(user_id)).flat_map do |grant_id|
         {name: short_name.to_sym, params: {grant_id: grant_id}}
       end

--- a/app/models/infrastructure_facades/plgrid/grid_schedulers_deprecated/glite.rb
+++ b/app/models/infrastructure_facades/plgrid/grid_schedulers_deprecated/glite.rb
@@ -237,7 +237,7 @@ module GliteScheduler
     # Returns list of hashes representing distinct configurations of infrastructure
     # Subinfrastructures are distinguished by:
     #  * PLGrid hosts
-    def get_subinfrastructures(user_id)
+    def get_infrastructure_configurations(user_id)
       self.class.available_hosts.map do |host|
         {name: short_name.to_sym, params: {plgrid_host: host}}
       end

--- a/app/models/infrastructure_facades/plgrid/pl_grid_scheduler_base.rb
+++ b/app/models/infrastructure_facades/plgrid/pl_grid_scheduler_base.rb
@@ -11,7 +11,7 @@
 # - status(ssh, record) -> job state in queue mapped to: :initializing, :running, :deactivated, :error
 # - clean_after_job(ssh, record) - cleans UI user's account from temporary files
 # - get_log(ssh, record) -> String with stdout+stderr contents for job
-# - get_subinfrastructures(user_id) -> list of hashes representing distinct configurations of infrastructure
+# - get_infrastructure_configurations(user_id) -> list of hashes representing distinct configurations of infrastructure
 
 require 'infrastructure_facades/shell_commands'
 require 'infrastructure_facades/ssh_accessed_infrastructure'

--- a/app/models/infrastructure_facades/private_machine_facade.rb
+++ b/app/models/infrastructure_facades/private_machine_facade.rb
@@ -214,7 +214,7 @@ class PrivateMachineFacade < InfrastructureFacade
   # Returns list of hashes representing distinct configurations of infrastructure
   # Subinfrastructures are distinguished by:
   #  * private machine credentials
-  def get_subinfrastructures(user_id)
+  def get_infrastructure_configurations(user_id)
     PrivateMachineCredentials.where(user_id: user_id).map do |credentials|
       {name: short_name.to_sym, params: {credentials_id: credentials.id.to_s}}
     end

--- a/app/models/workers_scaling/algorithm_factory.rb
+++ b/app/models/workers_scaling/algorithm_factory.rb
@@ -118,7 +118,7 @@ module WorkersScaling
     ##
     # Starts workers scaling with default configuration for PLGrid
     def self.plgrid_default(experiment_id, user_id)
-      infrastructures = InfrastructureFacadeFactory.get_facade_for(:qsub).get_subinfrastructures(user_id)
+      infrastructures = InfrastructureFacadeFactory.get_facade_for(:qsub).get_infrastructure_configurations(user_id)
       if infrastructures.blank?
         raise InfrastructureErrors::NoCredentialsError.new('Missing credentials for PlGrid resources')
       end

--- a/app/models/workers_scaling/algorithms/resources_usage_minimization.rb
+++ b/app/models/workers_scaling/algorithms/resources_usage_minimization.rb
@@ -40,7 +40,7 @@ module WorkersScaling
     def experiment_status_check
       LOGGER.debug 'experiment_status_check'
       @experiment.reload
-      current_makespan = @experiment_statistics.makespan(cond: Query::RUNNING_WORKERS)
+      current_makespan = @experiment_statistics.makespan(cond: Query::Workers::RUNNING_WITH_FINISHED_SIMULATIONS)
       case time_constraint_check(current_makespan, planned_finish_time - Time.now)
         when :increase
           increase_computational_power
@@ -80,7 +80,8 @@ module WorkersScaling
 
       # calculate average infrastructures throughput
       infrastructures_throughput = @resources_interface.get_available_infrastructures.map do |infrastructure|
-        statistics = @experiment_statistics.get_infrastructure_statistics(infrastructure, cond: Query::RUNNING_WORKERS)
+        statistics = @experiment_statistics.get_infrastructure_statistics(
+            infrastructure, cond: Query::Workers::RUNNING_WITH_FINISHED_SIMULATIONS)
         {infrastructure: infrastructure, statistics: statistics}
       end
 
@@ -124,7 +125,7 @@ module WorkersScaling
     # Stops Workers with lowest throughput first
     def decrease_computational_power
       LOGGER.debug 'Need to decrease computational power'
-      if @resources_interface.count_all_workers(cond: Query::STOPPING_WORKERS) > 0
+      if @resources_interface.count_all_workers(cond: Query::Workers::STOPPING) > 0
         LOGGER.debug 'There are stopping Workers already'
         return
       end
@@ -136,7 +137,9 @@ module WorkersScaling
 
       # get all workers with their throughput
       workers_throughput = @resources_interface.get_available_infrastructures.flat_map do |infrastructure|
-        @resources_interface.get_workers_records_list(infrastructure, cond: Query::RUNNING_WORKERS).map do |worker|
+        @resources_interface
+            .get_workers_records_list(infrastructure, cond: Query::Workers::RUNNING_WITH_FINISHED_SIMULATIONS)
+            .map do |worker|
           {sm_uuid: worker.sm_uuid, throughput: @experiment_statistics.worker_throughput(worker.sm_uuid)}
         end
       end

--- a/app/models/workers_scaling/experiment_statistics.rb
+++ b/app/models/workers_scaling/experiment_statistics.rb
@@ -114,7 +114,7 @@ module WorkersScaling
     # Return number of simulations to run
     def count_not_finished_simulations
       @experiment.reload
-      [@experiment.size - @experiment.count_done_simulations, 0.0].max
+      [@experiment.size - @experiment.count_done_simulations, 0].max
     end
 
   end

--- a/app/models/workers_scaling/experiment_statistics.rb
+++ b/app/models/workers_scaling/experiment_statistics.rb
@@ -31,7 +31,7 @@ module WorkersScaling
     # Possible cond and opts can be found in MongoActiveRecord#where.
     # By default only running workers are included into calculations.
     def infrastructure_throughput(infrastructure, params = {})
-      params[:cond] = Query::RUNNING_WORKERS unless params.has_key? :cond
+      params[:cond] = Query::Workers::RUNNING_WITH_FINISHED_SIMULATIONS unless params.has_key? :cond
       workers_for_infrastructure = @resources_interface.get_workers_records_list(infrastructure, params)
       workers_for_infrastructure.map {|worker| calculate_worker_throughput(worker)}
         .reduce(0.0, :+) / Float(workers_for_infrastructure.size)
@@ -47,7 +47,7 @@ module WorkersScaling
     # Possible cond and opts can be found in MongoActiveRecord#where.
     # By default only running workers are included into calculations.
     def system_throughput(params = {})
-      params[:cond] = Query::RUNNING_WORKERS unless params.has_key? :cond
+      params[:cond] = Query::Workers::RUNNING_WITH_FINISHED_SIMULATIONS unless params.has_key? :cond
       @resources_interface.get_enabled_infrastructures.map do |infrastructure|
         @resources_interface.get_workers_records_list(infrastructure, params)
           .map {|worker| calculate_worker_throughput worker}
@@ -60,7 +60,7 @@ module WorkersScaling
     # Target throughput is calculated as:
     #   throughput[sim/s] = simulations_to_run/(planned_finish_time - Time.now)
     def target_throughput(planned_finish_time)
-      simulations_to_run = count_simulations_to_run
+      simulations_to_run = count_not_finished_simulations
       return simulations_to_run if simulations_to_run == 0.0
       simulations_to_run / [Float(planned_finish_time - Time.now), 0.0].max
     end
@@ -76,8 +76,8 @@ module WorkersScaling
     # Possible cond and opts can be found in MongoActiveRecord#where.
     # By default only running workers are included into calculations.
     def makespan(params = {})
-      params[:cond] = Query::RUNNING_WORKERS unless params.has_key? :cond
-      simulations_to_run = count_simulations_to_run
+      params[:cond] = Query::Workers::RUNNING_WITH_FINISHED_SIMULATIONS unless params.has_key? :cond
+      simulations_to_run = count_not_finished_simulations
       return simulations_to_run if simulations_to_run == 0.0
       simulations_to_run / Float(system_throughput(params))
     end
@@ -95,7 +95,7 @@ module WorkersScaling
     # By default only running workers are included into calculations.
     # Raises InfrastructureError
     def get_infrastructure_statistics(infrastructure, params = {})
-      params[:cond] = Query::RUNNING_WORKERS unless params.has_key? :cond
+      params[:cond] = Query::Workers::RUNNING_WITH_FINISHED_SIMULATIONS unless params.has_key? :cond
       {
           average_throughput: infrastructure_throughput(infrastructure, params),
           workers_count: @resources_interface.get_workers_records_count(infrastructure, params)
@@ -112,7 +112,7 @@ module WorkersScaling
     
     ##
     # Return number of simulations to run
-    def count_simulations_to_run
+    def count_not_finished_simulations
       @experiment.reload
       [@experiment.size - @experiment.count_done_simulations, 0.0].max
     end

--- a/app/models/workers_scaling/utils/query.rb
+++ b/app/models/workers_scaling/utils/query.rb
@@ -1,40 +1,47 @@
 module WorkersScaling
   ##
-  # Module containing global Workers queries for WorkersScaling module
+  # Module containing global queries for WorkersScaling module
   module Query
-    ##
-    # Initializing - state is :created or :initializing
-    INITIALIZING_WORKERS = {state: {'$in' => [:created, :initializing]}}
+    # Section with workers queries
+    module Workers
+      ##
+      # Initializing - state is :created or :initializing
+      INITIALIZING = {state: {'$in' => [:created, :initializing]}}
 
-    ##
-    # Starting - state is :running and no simulation is finished
-    STARTING_WORKERS = {'$and' => [
-      {state: :running},
-      {'$or' => [
-          {finished_simulations: {'$exists' => false}},
-          {finished_simulations: 0}
+      ##
+      # Starting - state is :running and no simulation is finished
+      RUNNING_WITHOUT_FINISHED_SIMULATIONS = {'$and' => [
+          {state: :running},
+          {'$or' => [
+              {finished_simulations: {'$exists' => false}},
+              {finished_simulations: 0}
+          ]}
       ]}
-    ]}
 
-    ##
-    # Running - state is :running and at least one simulation is finished
-    RUNNING_WORKERS  = {'$and' => [
-      {state: :running},
-      {finished_simulations: {'$gt' => 0}}
-    ]}
-
-    ##
-    # Stopping - state is :terminating or state is not :error and simulations_limit is already set
-    STOPPING_WORKERS = {'$or' => [
-      {state: :terminating},
-      {'and' => [
-        {state: {'$ne' => :error}},
-        {simulations_left: {'$exists' => true}}
+      ##
+      # Running - state is :running and at least one simulation is finished
+      RUNNING_WITH_FINISHED_SIMULATIONS  = {'$and' => [
+          {state: :running},
+          {finished_simulations: {'$gt' => 0}}
       ]}
-    ]}
 
-    ##
-    # Limited - state is not :error (limited Workers are Workers that count against limits)
-    LIMITED_WORKERS = {state: {'$ne' => :error}}
+      ##
+      # Stopping - state is :terminating or state is not :error and simulations_limit is already set
+      STOPPING = {'$or' => [
+          {state: :terminating},
+          {'and' => [
+              {state: {'$ne' => :error}},
+              {simulations_left: {'$exists' => true}}
+          ]}
+      ]}
+
+      ##
+      # Not error - state is not :error (limited Workers are Workers that count against limits)
+      NOT_ERROR = {state: {'$ne' => :error}}
+
+      ##
+      # Error - state is :error
+      ERROR = {state: {'$eq' => :error}}
+    end
   end
 end

--- a/app/views/experiments/new.html.haml
+++ b/app/views/experiments/new.html.haml
@@ -1,7 +1,7 @@
 - es_url = sample_service_url('experiment_supervisors')
 - supervisor_ids = get_supervisor_ids(es_url)
 - wss_algorithms_descriptions = workers_scaling_algorithms_description
-- plgrid_default_enabled = !InfrastructureFacadeFactory.get_facade_for(:qsub).get_subinfrastructures(current_user.id).blank?
+- plgrid_default_enabled = !InfrastructureFacadeFactory.get_facade_for(:qsub).get_infrastructure_configurations(current_user.id).blank?
 
 - content_for :title, t('.title')
 - content_for :help, raw(t('help.simulations.conduct'))

--- a/test/models/workers_scaling/experiment_resources_interface_test.rb
+++ b/test/models/workers_scaling/experiment_resources_interface_test.rb
@@ -244,8 +244,7 @@ class ExperimentResourcesInterfaceTest < ActiveSupport::TestCase
     @experiment.expects(:count_simulations_to_run).returns(simulations_to_run)
     @resources_interface.stubs(:current_infrastructure_limit).returns(requested_amount)
     # when
-    real_amount, _ = @resources_interface.send(:calculate_needed_workers, requested_amount,
-                                               SAMPLE_INFRASTRUCTURE)
+    real_amount, _ = @resources_interface.send(:calculate_needed_workers, requested_amount, SAMPLE_INFRASTRUCTURE)
     # then
     assert_equal simulations_to_run, real_amount
   end
@@ -258,35 +257,26 @@ class ExperimentResourcesInterfaceTest < ActiveSupport::TestCase
     @experiment.stubs(:count_simulations_to_run).returns(requested_amount)
     @resources_interface.expects(:current_infrastructure_limit).returns(workers_limit)
     # when
-    real_amount, _ = @resources_interface.send(:calculate_needed_workers, requested_amount,
-                                               SAMPLE_INFRASTRUCTURE)
+    real_amount, _ = @resources_interface.send(:calculate_needed_workers, requested_amount, SAMPLE_INFRASTRUCTURE)
     # then
     assert_equal workers_limit, real_amount
   end
 
-  SAMPLE_INFRASTRUCTURES_LIST = [
-      {:name => "Private resources", :infrastructure_name => "private_machine", :enabled => true},
-      {:name => "Dummy", :infrastructure_name => "dummy", :enabled => true},
-      {:name => "PL-Grid", :group => "plgrid", :children => [
-          {:name => "PL-Grid PBS", :infrastructure_name => "qsub", :enabled => true, :group => "plgrid"},
-          {:name => "PL-Grid QosCosGrid", :infrastructure_name => "qcg", :enabled => true, :group => "plgrid"}]},
-      {:name => "Clouds", :group => "cloud", :children => [
-          {:name => "Google Compute Engine", :infrastructure_name => "google", :enabled => false, :group => "cloud"},
-          {:name => "PLGrid Cloud", :infrastructure_name => "pl_cloud", :enabled => false, :group => "cloud"},
-          {:name => "Amazon Elastic Compute Cloud", :infrastructure_name => "amazon", :enabled => false,
-           :group => "cloud"}]}
-  ]
-  ENABLED_INFRASTRUCTURES_LIST = [
-      {name: :private_machine, params: {}},
-      {name: :dummy, params: {}},
-      {name: :qsub, params: {}},
-      {name: :qcg, params: {}}
-  ].map! { |inf| ActiveSupport::HashWithIndifferentAccess.new(inf) }
+  ENABLED_INFRASTRUCTURE_CONFIGURATION = ActiveSupport::HashWithIndifferentAccess.new({name: :enabled, params: {}})
 
   test 'get_enabled_infrastructures should return enabled infrastructures in infrastructure_configuration format' do
     # given
-    InfrastructureFacadeFactory.stubs(:list_infrastructures).returns(SAMPLE_INFRASTRUCTURES_LIST)
+    enabled_infrastructure = mock do
+      stubs(:enabled_for_user?).returns(true)
+      stubs(:short_name).returns('enabled')
+    end
+    disabled_infrastructure = mock do
+      stubs(:enabled_for_user?).returns(false)
+    end
+
+    InfrastructureFacadeFactory.stubs(:get_all_infrastructures)
+        .returns([enabled_infrastructure, disabled_infrastructure])
     # when, then
-    assert_equal ENABLED_INFRASTRUCTURES_LIST, @resources_interface.get_enabled_infrastructures
+    assert_equal [ENABLED_INFRASTRUCTURE_CONFIGURATION], @resources_interface.get_enabled_infrastructures
   end
 end

--- a/test/models/workers_scaling/experiment_resources_interface_test.rb
+++ b/test/models/workers_scaling/experiment_resources_interface_test.rb
@@ -5,8 +5,8 @@ class ExperimentResourcesInterfaceTest < ActiveSupport::TestCase
 
   EXPERIMENT_ID = 'some_id'
   USER_ID = BSON::ObjectId.new
-  # TODO change to InfrastructureId class
   SAMPLE_INFRASTRUCTURE = ActiveSupport::HashWithIndifferentAccess.new({name: 'name', params: {foo: 'bar'}})
+  SAMPLE_AMOUNT = 10
   LIMIT = 10
   SAMPLE_LIMITS = [
       {infrastructure: SAMPLE_INFRASTRUCTURE, limit: LIMIT}
@@ -33,97 +33,260 @@ class ExperimentResourcesInterfaceTest < ActiveSupport::TestCase
   test 'current_infrastructure_limit should return zero for infrastructure without limit' do
     # given
     resources_interface = WorkersScaling::ExperimentResourcesInterface.new(@experiment, USER_ID, {})
-    # when
+    # when, then
     assert_equal 0, resources_interface.current_infrastructure_limit(SAMPLE_INFRASTRUCTURE)
-    # then
   end
 
   test 'current_infrastructure_limit should return limit value when workers are not running' do
     # given
     @resources_interface.expects(:get_workers_records_count).returns(0)
-    # when
+    # when, then
     assert_equal LIMIT, @resources_interface.current_infrastructure_limit(SAMPLE_INFRASTRUCTURE)
-    # then
   end
 
   test 'current_infrastructure_limit should return limit reduced by running workers when workers are running' do
     # given
     working_workers = 5
     @resources_interface.expects(:get_workers_records_count).returns(working_workers)
-    # when
+    # when, then
     assert_equal LIMIT - working_workers, @resources_interface.current_infrastructure_limit(SAMPLE_INFRASTRUCTURE)
-    # then
   end
 
   test 'current_infrastructure_limit should return zero when to much workers are running' do
     # given
     working_workers = LIMIT + 5
     @resources_interface.expects(:get_workers_records_count).returns(working_workers)
-    # when
+    # when, then
     assert_equal 0, @resources_interface.current_infrastructure_limit(SAMPLE_INFRASTRUCTURE)
-    # then
   end
 
-  test 'schedule_workers should start workers with given config' do
+  test 'schedule_workers should start workers with given config and return theirs sm_uuids' do
     # given
-    amount = 10
-    additional_params = {param1: 'value'}
-    final_params = additional_params.merge(SAMPLE_INFRASTRUCTURE[:params]).merge!(DEFAULT_SCHEDULE_WORK_PARAMS)
+    final_params = SAMPLE_INFRASTRUCTURE[:params].merge(DEFAULT_SCHEDULE_WORK_PARAMS)
     final_params = ActiveSupport::HashWithIndifferentAccess.new(final_params)
     start_simulation_managers_result = []
     schedule_workers_result = []
-    (1..amount).each do |id|
+    (1..SAMPLE_AMOUNT).each do |id|
       start_simulation_managers_result << mock do
         stubs(:sm_uuid).returns(id)
       end
       schedule_workers_result << id
     end
     facade_mock = mock
-    facade_mock.stubs(:query_simulation_manager_records).returns(@sm_record_class)
-    facade_mock.expects(:start_simulation_managers).with(USER_ID, amount, EXPERIMENT_ID, equals(final_params))
+    facade_mock.expects(:start_simulation_managers).with(USER_ID, SAMPLE_AMOUNT, EXPERIMENT_ID, equals(final_params))
         .returns(start_simulation_managers_result)
 
+    @resources_interface.stubs(:infrastructure_not_working?).returns(false)
+    @resources_interface.stubs(:calculate_needed_workers).returns([SAMPLE_AMOUNT, []])
     @resources_interface.expects(:get_facade_for).at_least_once.with(SAMPLE_INFRASTRUCTURE[:name]).returns(facade_mock)
-    @resources_interface.stubs(:current_infrastructure_limit).returns(Float::INFINITY)
 
-    # when
-    assert_equal schedule_workers_result, @resources_interface.schedule_workers(amount,
-                                                                                SAMPLE_INFRASTRUCTURE,
-                                                                                additional_params)
-    # then
+    # when, then
+    assert_equal schedule_workers_result, @resources_interface.schedule_workers(SAMPLE_AMOUNT, SAMPLE_INFRASTRUCTURE)
   end
 
-  test 'schedule workers should not start workers when limit is zero' do
+  test 'schedule_workers should not start workers when real amount is zero' do
     # given
-    amount = 10
-    @resources_interface.stubs(:current_infrastructure_limit).returns(0)
-    @resources_interface.stubs(:get_workers_records_list).returns([])
-    # when
-    assert_equal [], @resources_interface.schedule_workers(amount, SAMPLE_INFRASTRUCTURE)
-    # then
+    @resources_interface.stubs(:infrastructure_not_working?).returns(false)
+    @resources_interface.stubs(:calculate_needed_workers).returns([0, []])
+    # when, then
+    assert_equal [], @resources_interface.schedule_workers(SAMPLE_AMOUNT, SAMPLE_INFRASTRUCTURE)
   end
 
-  test 'schedule workers should schedule less workers when limit is lower than requested amount' do
-    # given
-    amount = LIMIT + 10
-    facade_mock = mock
-    facade_mock.stubs(:query_simulation_manager_records).returns(@sm_record_class)
-
-    start_simulation_managers_result = []
-    (1..LIMIT).each do |id|
-      start_simulation_managers_result << mock do
+  ##
+  # Returns list containing workers records stubs
+  # @param [Fixnum] amount
+  # @return [Array<#sm_uuid>]
+  def get_workers_stubs(amount)
+    workers_stubs = []
+    (1..amount).each do |id|
+      workers_stubs << mock do
         stubs(:sm_uuid).returns(id)
       end
     end
+    workers_stubs
+  end
+
+  test 'schedule_workers should schedule less workers when real amount is lower than requested amount' do
+    # given
+    amount = LIMIT + 10
+    start_simulation_managers_result = get_workers_stubs(LIMIT)
+    facade_mock = mock
     facade_mock.expects(:start_simulation_managers)
         .with(anything, LIMIT, anything, anything)
         .returns(start_simulation_managers_result)
 
+    @resources_interface.stubs(:infrastructure_not_working?).returns(false)
     @resources_interface.stubs(:get_facade_for).returns(facade_mock)
-    @resources_interface.expects(:current_infrastructure_limit).returns(LIMIT)
-    # when
-    assert_equal LIMIT, @resources_interface.schedule_workers(amount, SAMPLE_INFRASTRUCTURE).count
-    # then
+    @resources_interface.expects(:calculate_needed_workers).returns([LIMIT, []])
+    # when, then
+    @resources_interface.schedule_workers(amount, SAMPLE_INFRASTRUCTURE)
   end
 
+  test 'schedule_workers should not start workers when infrastructure is not working' do
+    # given
+    @resources_interface.expects(:infrastructure_not_working?).returns(true)
+    @resources_interface.expects(:calculate_needed_workers).never
+    @resources_interface.expects(:get_facade_for).never
+    # when, then
+    assert_equal 0, @resources_interface.schedule_workers(SAMPLE_AMOUNT, SAMPLE_INFRASTRUCTURE).count
+  end
+
+  test 'schedule_workers should raise AccessDeniedError when passed infrastructure_configuration id not allowed' do
+    # given
+    resources_interface = WorkersScaling::ExperimentResourcesInterface.new(@experiment, USER_ID, [])
+    resources_interface.stubs(:infrastructure_configs_equal?).returns(false)
+    # when, then
+    assert_raises AccessDeniedError do
+      resources_interface.schedule_workers(SAMPLE_AMOUNT, SAMPLE_INFRASTRUCTURE)
+    end
+  end
+
+  test 'schedule_workers should include already_scheduled_workers in final workers sm_uuids list' do
+    # given
+    amount = 10
+    already_scheduled_workers_count = 5
+    start_simulation_managers_result = get_workers_stubs(amount - already_scheduled_workers_count)
+    already_scheduled_workers = (1..already_scheduled_workers_count).to_a
+    facade_mock = mock
+    facade_mock.expects(:start_simulation_managers)
+        .with(anything, anything, anything, anything)
+        .returns(start_simulation_managers_result)
+
+    @resources_interface.stubs(:infrastructure_not_working?).returns(false)
+    @resources_interface.stubs(:get_facade_for).returns(facade_mock)
+    @resources_interface.expects(:calculate_needed_workers)
+        .returns([already_scheduled_workers_count, already_scheduled_workers])
+    # when, then
+    assert_equal start_simulation_managers_result.map(&:sm_uuid) + already_scheduled_workers,
+                 @resources_interface.schedule_workers(amount, SAMPLE_INFRASTRUCTURE)
+  end
+
+  test 'infrastructure_not_working? should return true when too much workers failed to work' do
+    # given
+    @resources_interface.expects(:get_workers_records_count)
+        .with(anything, WorkersScaling::Query::Workers::ERROR)
+        .returns(WorkersScaling::ExperimentResourcesInterface::MAXIMUM_NUMBER_OF_FAILED_WORKERS + 5)
+    # when, then
+    assert_equal true, @resources_interface.send(:infrastructure_not_working?, SAMPLE_INFRASTRUCTURE)
+  end
+
+  test 'infrastructure_not_working? should return false when not enough workers failed to work' do
+    # given
+    @resources_interface.expects(:get_workers_records_count)
+        .with(anything, WorkersScaling::Query::Workers::ERROR)
+        .returns(0)
+    # when, then
+    assert_equal false, @resources_interface.send(:infrastructure_not_working?, SAMPLE_INFRASTRUCTURE)
+  end
+
+  test 'calculate_needed_workers should include running workers without finished simulations in requested amount' do
+    # given
+    requested_amount = 10
+    starting_workers = 5
+    @resources_interface.stubs(:get_workers_records_list).returns([])
+    starting_workers_records = get_workers_stubs(starting_workers)
+    @resources_interface.expects(:get_workers_records_list)
+        .with(anything, equals({cond: WorkersScaling::Query::Workers::RUNNING_WITHOUT_FINISHED_SIMULATIONS}))
+        .returns(starting_workers_records)
+    @experiment.stubs(:count_simulations_to_run).returns(requested_amount)
+    @resources_interface.stubs(:current_infrastructure_limit).returns(requested_amount)
+    # when
+    real_amount, already_scheduled_workers = @resources_interface.send(:calculate_needed_workers, requested_amount,
+                                                                       SAMPLE_INFRASTRUCTURE)
+    # then
+    assert_equal requested_amount - starting_workers, real_amount
+    assert_equal starting_workers_records.map(&:sm_uuid), already_scheduled_workers
+  end
+
+  test 'calculate_needed_workers should include initializing workers in requested amount' do
+    # given
+    requested_amount = 10
+    initializing_workers = 5
+    @resources_interface.stubs(:get_workers_records_list).returns([])
+    initializing_workers_records = get_workers_stubs(initializing_workers)
+    @resources_interface.expects(:get_workers_records_list)
+        .with(anything, equals({cond: WorkersScaling::Query::Workers::INITIALIZING}))
+        .returns(initializing_workers_records)
+    @experiment.stubs(:count_simulations_to_run).returns(requested_amount)
+    @resources_interface.stubs(:current_infrastructure_limit).returns(requested_amount)
+    # when
+    real_amount, already_scheduled_workers = @resources_interface.send(:calculate_needed_workers, requested_amount,
+                                                                       SAMPLE_INFRASTRUCTURE)
+    # then
+    assert_equal requested_amount - initializing_workers, real_amount
+    assert_equal initializing_workers_records.map(&:sm_uuid), already_scheduled_workers
+  end
+
+  test 'calculate_needed_workers should include initializing workers in simulations left' do
+    # given
+    requested_amount = 20
+    simulations_to_run = 10
+    initializing_workers = 5
+    @resources_interface.stubs(:get_workers_records_list).returns([])
+    initializing_workers_records = get_workers_stubs(initializing_workers)
+    @resources_interface.expects(:get_workers_records_list)
+        .with(anything, equals({cond: WorkersScaling::Query::Workers::INITIALIZING}))
+        .returns(initializing_workers_records)
+    @experiment.expects(:count_simulations_to_run).returns(simulations_to_run)
+    @resources_interface.stubs(:current_infrastructure_limit).returns(requested_amount)
+    # when
+    real_amount, _ = @resources_interface.send(:calculate_needed_workers, requested_amount,
+                                               SAMPLE_INFRASTRUCTURE)
+    # then
+    assert_equal simulations_to_run - initializing_workers, real_amount
+  end
+
+  test 'calculate_needed_workers should limit needed workers to number of left simulations' do
+    # given
+    requested_amount = 20
+    simulations_to_run = 10
+    @resources_interface.stubs(:get_workers_records_list).returns([])
+    @experiment.expects(:count_simulations_to_run).returns(simulations_to_run)
+    @resources_interface.stubs(:current_infrastructure_limit).returns(requested_amount)
+    # when
+    real_amount, _ = @resources_interface.send(:calculate_needed_workers, requested_amount,
+                                               SAMPLE_INFRASTRUCTURE)
+    # then
+    assert_equal simulations_to_run, real_amount
+  end
+
+  test 'calculate_needed_workers should limit needed workers to imposed limit' do
+    # given
+    requested_amount = 20
+    workers_limit = 10
+    @resources_interface.stubs(:get_workers_records_list).returns([])
+    @experiment.stubs(:count_simulations_to_run).returns(requested_amount)
+    @resources_interface.expects(:current_infrastructure_limit).returns(workers_limit)
+    # when
+    real_amount, _ = @resources_interface.send(:calculate_needed_workers, requested_amount,
+                                               SAMPLE_INFRASTRUCTURE)
+    # then
+    assert_equal workers_limit, real_amount
+  end
+
+  SAMPLE_INFRASTRUCTURES_LIST = [
+      {:name => "Private resources", :infrastructure_name => "private_machine", :enabled => true},
+      {:name => "Dummy", :infrastructure_name => "dummy", :enabled => true},
+      {:name => "PL-Grid", :group => "plgrid", :children => [
+          {:name => "PL-Grid PBS", :infrastructure_name => "qsub", :enabled => true, :group => "plgrid"},
+          {:name => "PL-Grid QosCosGrid", :infrastructure_name => "qcg", :enabled => true, :group => "plgrid"}]},
+      {:name => "Clouds", :group => "cloud", :children => [
+          {:name => "Google Compute Engine", :infrastructure_name => "google", :enabled => false, :group => "cloud"},
+          {:name => "PLGrid Cloud", :infrastructure_name => "pl_cloud", :enabled => false, :group => "cloud"},
+          {:name => "Amazon Elastic Compute Cloud", :infrastructure_name => "amazon", :enabled => false,
+           :group => "cloud"}]}
+  ]
+  ENABLED_INFRASTRUCTURES_LIST = [
+      {name: :private_machine, params: {}},
+      {name: :dummy, params: {}},
+      {name: :qsub, params: {}},
+      {name: :qcg, params: {}}
+  ].map! { |inf| ActiveSupport::HashWithIndifferentAccess.new(inf) }
+
+  test 'get_enabled_infrastructures should return enabled infrastructures in infrastructure_configuration format' do
+    # given
+    InfrastructureFacadeFactory.stubs(:list_infrastructures).returns(SAMPLE_INFRASTRUCTURES_LIST)
+    # when, then
+    assert_equal ENABLED_INFRASTRUCTURES_LIST, @resources_interface.get_enabled_infrastructures
+  end
 end

--- a/test/models/workers_scaling/experiment_statistics_test.rb
+++ b/test/models/workers_scaling/experiment_statistics_test.rb
@@ -6,7 +6,7 @@ class ExperimentStatisticsTest < ActiveSupport::TestCase
     @experiment_statistics = WorkersScaling::ExperimentStatistics.new(stub_everything, stub_everything)
   end
 
-  test 'count_simulations_to_run should always return non-negative number' do
+  test 'count_not_finished_simulations should always return non-negative number' do
     # given
     experiment = mock do
       stubs(:size).returns(0)
@@ -20,7 +20,7 @@ class ExperimentStatisticsTest < ActiveSupport::TestCase
     assert simulations_to_run >= 0, "Number of simulations to run must be non-negative, got #{simulations_to_run}"
   end
 
-  test 'count_simulations_to_run should always return current data' do
+  test 'count_not_finished_simulations should always return current data' do
     # given
     experiment = mock do
       expects(:reload)
@@ -32,7 +32,7 @@ class ExperimentStatisticsTest < ActiveSupport::TestCase
     experiment_statistics.send(:count_not_finished_simulations)
   end
 
-  test 'count_simulations_to_run should return number of simulations to run' do
+  test 'count_not_finished_simulations should return number of simulations to run' do
     # given
     experiment_size = 10
     done_simulations = 5

--- a/test/models/workers_scaling/experiment_statistics_test.rb
+++ b/test/models/workers_scaling/experiment_statistics_test.rb
@@ -15,7 +15,7 @@ class ExperimentStatisticsTest < ActiveSupport::TestCase
     end
     experiment_statistics = WorkersScaling::ExperimentStatistics.new(experiment, mock)
     # when
-    simulations_to_run = experiment_statistics.send(:count_simulations_to_run)
+    simulations_to_run = experiment_statistics.send(:count_not_finished_simulations)
     # then
     assert simulations_to_run >= 0, "Number of simulations to run must be non-negative, got #{simulations_to_run}"
   end
@@ -29,7 +29,7 @@ class ExperimentStatisticsTest < ActiveSupport::TestCase
     end
     experiment_statistics = WorkersScaling::ExperimentStatistics.new(experiment, mock)
     # when, then
-    experiment_statistics.send(:count_simulations_to_run)
+    experiment_statistics.send(:count_not_finished_simulations)
   end
 
   test 'count_simulations_to_run should return number of simulations to run' do
@@ -44,14 +44,14 @@ class ExperimentStatisticsTest < ActiveSupport::TestCase
     end
     experiment_statistics = WorkersScaling::ExperimentStatistics.new(experiment, mock)
     # when
-    simulations_to_run = experiment_statistics.send(:count_simulations_to_run)
+    simulations_to_run = experiment_statistics.send(:count_not_finished_simulations)
     # then
     assert_equal expected_simulations_to_run, simulations_to_run
   end
 
   test 'makespan should be zero when there are no simulations to run' do
     # given
-    @experiment_statistics.stubs(:count_simulations_to_run).returns(0)
+    @experiment_statistics.stubs(:count_not_finished_simulations).returns(0)
     @experiment_statistics.stubs(:system_throughput).returns(0)
     # when
     makespan = @experiment_statistics.makespan
@@ -61,7 +61,7 @@ class ExperimentStatisticsTest < ActiveSupport::TestCase
 
   test 'makespan should be infinity when system_throughput is zero and there are simulations to run' do
     # given
-    @experiment_statistics.stubs(:count_simulations_to_run).returns(1)
+    @experiment_statistics.stubs(:count_not_finished_simulations).returns(1)
     @experiment_statistics.stubs(:system_throughput).returns(0)
     # when
     makespan = @experiment_statistics.makespan
@@ -74,7 +74,7 @@ class ExperimentStatisticsTest < ActiveSupport::TestCase
     system_throughput = 1
     simulations_to_run = 1
     expected_makespan = simulations_to_run / system_throughput
-    @experiment_statistics.stubs(:count_simulations_to_run).returns(simulations_to_run)
+    @experiment_statistics.stubs(:count_not_finished_simulations).returns(simulations_to_run)
     @experiment_statistics.stubs(:system_throughput).returns(system_throughput)
     # when
     makespan = @experiment_statistics.makespan
@@ -84,7 +84,7 @@ class ExperimentStatisticsTest < ActiveSupport::TestCase
 
   test 'target_throughput should be zero when there are no simulations to run' do
     # given
-    @experiment_statistics.stubs(:count_simulations_to_run).returns(0)
+    @experiment_statistics.stubs(:count_not_finished_simulations).returns(0)
     Time.stubs(:now).returns(0)
     # when
     target_throughput = @experiment_statistics.target_throughput(0)
@@ -94,7 +94,7 @@ class ExperimentStatisticsTest < ActiveSupport::TestCase
 
   test 'target_throughput should always be non-negative number' do
     # given
-    @experiment_statistics.stubs(:count_simulations_to_run).returns(1)
+    @experiment_statistics.stubs(:count_not_finished_simulations).returns(1)
     Time.stubs(:now).returns(1)
     # when
     target_throughput = @experiment_statistics.target_throughput(0)
@@ -108,7 +108,7 @@ class ExperimentStatisticsTest < ActiveSupport::TestCase
     time_now = 0
     planned_finish_time = 1
     expected_target_throughput = simulations_to_run / (planned_finish_time - time_now)
-    @experiment_statistics.stubs(:count_simulations_to_run).returns(simulations_to_run)
+    @experiment_statistics.stubs(:count_not_finished_simulations).returns(simulations_to_run)
     Time.stubs(:now).returns(time_now)
     # when
     target_throughput = @experiment_statistics.target_throughput(planned_finish_time)


### PR DESCRIPTION
https://jira.plgrid.pl/jira/browse/SCAL-1191

Disables workers scheduling on infrastructures with too many workers in error state.
  * configuration check with get_subinfrastructures discarded
  * renaming workers queries constants
  * schedule_workers method refactoring
  * change infrastructure to now proper infrastructure_config
  * count_simulations_to_run method in experiment
  * renamed count_simulations_to_run in experiment statistics to more explicit name

@kliput ta poprawka z obsługą błędów powoduje że użycie get_subinfrastructures nie jest już konieczne, dzięki czemu zostało usunięte co rozwiązało problem z https://jira.plgrid.pl/jira/browse/SCAL-1202