### PR TITLE
SCAL-1214: Fixing error occurring on missing simulations_left

### DIFF
--- a/app/controllers/simulations_controller.rb
+++ b/app/controllers/simulations_controller.rb
@@ -367,7 +367,7 @@ class SimulationsController < ApplicationController
         response = {status: 'error', reason: e.to_s}
       end
 
-      if sm_record and (sm_record.simulations_left || Float::INFINITY) <= 0
+      if sm_record and sm_record.simulations_left <= 0
         InfrastructureFacadeFactory.get_facade_for(sm_record.infrastructure)
             .yield_simulation_manager(sm_record) do |sm|
           sm.stop

--- a/app/controllers/simulations_controller.rb
+++ b/app/controllers/simulations_controller.rb
@@ -367,7 +367,7 @@ class SimulationsController < ApplicationController
         response = {status: 'error', reason: e.to_s}
       end
 
-      if sm_record and sm_record.simulations_left <= 0
+      if sm_record and (sm_record.simulations_left || Float::INFINITY) <= 0
         InfrastructureFacadeFactory.get_facade_for(sm_record.infrastructure)
             .yield_simulation_manager(sm_record) do |sm|
           sm.stop

--- a/app/models/simulation_manager_record.rb
+++ b/app/models/simulation_manager_record.rb
@@ -207,6 +207,12 @@ module SimulationManagerRecord
     end
   end
 
+  ##
+  # Returns default infinity value when attribute simulations_left is not present
+  def simulations_left
+    attributes['simulations_left'] || Float::INFINITY
+  end
+
   def store_no_credentials
     unless self.no_credentials
       self.set_attribute('no_credentials', true)

--- a/app/models/simulation_manager_record.rb
+++ b/app/models/simulation_manager_record.rb
@@ -208,9 +208,9 @@ module SimulationManagerRecord
   end
 
   ##
-  # Returns default infinity value when attribute simulations_left is not present
-  def simulations_left
-    attributes['simulations_left'] || Float::INFINITY
+  # Returns true if attribute simulations_left is greater than zero or does not exist
+  def has_more_simulations_to_run?
+    (attributes['simulations_left'] || Float::INFINITY) > 0
   end
 
   def store_no_credentials

--- a/app/models/simulation_manager_record.rb
+++ b/app/models/simulation_manager_record.rb
@@ -208,9 +208,10 @@ module SimulationManagerRecord
   end
 
   ##
-  # Returns true if attribute simulations_left is greater than zero or does not exist
+  # Determines if simulation manager should run more simulations
+  # If attribute simulations_left is not set, returned value is always true
   def has_more_simulations_to_run?
-    (attributes['simulations_left'] || Float::INFINITY) > 0
+    (self.simulations_left || Float::INFINITY) > 0
   end
 
   def store_no_credentials

--- a/test/models/simulation_manager_record_test.rb
+++ b/test/models/simulation_manager_record_test.rb
@@ -152,4 +152,18 @@ class SimulationManagerRecordTest < MiniTest::Test
     assert_equal 'code1#_#code2', "#{attributes_mock[:cmd_to_execute_code]}"
   end
 
+  def test_simulations_left_field_existing
+    sm_record = MockRecord.new({})
+    sm_record.stubs(:attributes).returns('simulations_left' => 1)
+
+    assert_equal 1, sm_record.simulations_left
+  end
+
+  def test_simulations_left_field_not_existing
+    sm_record = MockRecord.new({})
+    sm_record.stubs(:attributes).returns({})
+
+    assert_equal Float::INFINITY, sm_record.simulations_left
+  end
+
 end

--- a/test/models/simulation_manager_record_test.rb
+++ b/test/models/simulation_manager_record_test.rb
@@ -152,18 +152,32 @@ class SimulationManagerRecordTest < MiniTest::Test
     assert_equal 'code1#_#code2', "#{attributes_mock[:cmd_to_execute_code]}"
   end
 
-  def test_simulations_left_field_existing
+  def test_has_more_simulations_to_run_field_greater_than_zero
     sm_record = MockRecord.new({})
     sm_record.stubs(:attributes).returns('simulations_left' => 1)
 
-    assert_equal 1, sm_record.simulations_left
+    assert sm_record.has_more_simulations_to_run?, 'Simulation Manager has more simulations to run when simulations_left is greater than 0'
   end
 
-  def test_simulations_left_field_not_existing
+  def test_has_more_simulations_to_run_field_equal_to_zero
+    sm_record = MockRecord.new({})
+    sm_record.stubs(:attributes).returns('simulations_left' => 0)
+
+    assert (not sm_record.has_more_simulations_to_run?), 'Simulation Manager has no more simulations to run when simulations_left is 0'
+  end
+
+  def test_has_more_simulations_to_run_field_lesser_than_zero
+    sm_record = MockRecord.new({})
+    sm_record.stubs(:attributes).returns('simulations_left' => -1)
+
+    assert (not sm_record.has_more_simulations_to_run?), 'Simulation Manager has no more simulations to run when simulations_left is lesser than 0'
+  end
+
+  def test_has_more_simulations_to_run_field_not_existing
     sm_record = MockRecord.new({})
     sm_record.stubs(:attributes).returns({})
 
-    assert_equal Float::INFINITY, sm_record.simulations_left
+    assert sm_record.has_more_simulations_to_run?, 'Simulation Manager has more simulations to run when simulations_left is not present'
   end
 
 end

--- a/test/models/simulation_manager_record_test.rb
+++ b/test/models/simulation_manager_record_test.rb
@@ -154,28 +154,28 @@ class SimulationManagerRecordTest < MiniTest::Test
 
   def test_has_more_simulations_to_run_field_greater_than_zero
     sm_record = MockRecord.new({})
-    sm_record.stubs(:attributes).returns('simulations_left' => 1)
+    sm_record.stubs(:simulations_left).returns(1)
 
     assert sm_record.has_more_simulations_to_run?, 'Simulation Manager has more simulations to run when simulations_left is greater than 0'
   end
 
   def test_has_more_simulations_to_run_field_equal_to_zero
     sm_record = MockRecord.new({})
-    sm_record.stubs(:attributes).returns('simulations_left' => 0)
+    sm_record.stubs(:simulations_left).returns(0)
 
     assert (not sm_record.has_more_simulations_to_run?), 'Simulation Manager has no more simulations to run when simulations_left is 0'
   end
 
   def test_has_more_simulations_to_run_field_lesser_than_zero
     sm_record = MockRecord.new({})
-    sm_record.stubs(:attributes).returns('simulations_left' => -1)
+    sm_record.stubs(:simulations_left).returns(-1)
 
     assert (not sm_record.has_more_simulations_to_run?), 'Simulation Manager has no more simulations to run when simulations_left is lesser than 0'
   end
 
   def test_has_more_simulations_to_run_field_not_existing
     sm_record = MockRecord.new({})
-    sm_record.stubs(:attributes).returns({})
+    sm_record.stubs(:simulations_left).returns(nil)
 
     assert sm_record.has_more_simulations_to_run?, 'Simulation Manager has more simulations to run when simulations_left is not present'
   end


### PR DESCRIPTION
 https://jira.plgrid.pl/jira/browse/SCAL-1214

 * When sm_record does not have field simulations_left, it is considered to be infinity.