### PR TITLE
SCAL-1222: Fixing missing params for workers

### DIFF
--- a/app/models/workers_scaling/algorithm_factory.rb
+++ b/app/models/workers_scaling/algorithm_factory.rb
@@ -96,7 +96,7 @@ module WorkersScaling
       if configuration.blank?
         raise InfrastructureErrors::NoCredentialsError.new('Missing credentials for PlGrid resources')
       end
-      configuration.merge!({time_limit: worker_time_limit, onsite_monitoring: ONSITE_MONITORING_ACTIVE})
+      configuration[:params].merge!({time_limit: worker_time_limit, onsite_monitoring: ONSITE_MONITORING_ACTIVE})
       self.create_algorithm(
           class_name: WorkersScaling::ResourcesUsageMaximization.get_class_name.to_sym,
           experiment_id: experiment_id,


### PR DESCRIPTION
https://jira.plgrid.pl/jira/browse/SCAL-1222

In plgrid default time_limit and onsite_monitoring were
added to resource configuration instead of its params.